### PR TITLE
Se crea boton para eliminar un doctor asociado a un paciente y ajustan filtros de doctores

### DIFF
--- a/client/src/components/Card/ButtonRemove.jsx
+++ b/client/src/components/Card/ButtonRemove.jsx
@@ -1,0 +1,25 @@
+import { IconButton } from "@material-ui/core";
+import DeleteIcon from "@mui/icons-material/Delete";
+import swal from "sweetalert";
+import { deleteDoctor } from "../../actions/index";
+import { useDispatch } from "react-redux";
+
+const ButtonRemove = ({ idPatient, idDoctor }) => {
+  const dispatch = useDispatch();
+  const handleClick = () => {
+    swal(" ¿Estás seguro? ", {
+      dangerMode: true,
+      buttons: { cancel: true, confirm: "Continuar" },
+    }).then((res) =>
+      res ? dispatch(deleteDoctor(idPatient, idDoctor)) : false
+    );
+  };
+  return (
+    <>
+      <IconButton onClick={handleClick} aria-label="delete" size="small">
+        <DeleteIcon fontSize="large" />
+      </IconButton>
+    </>
+  );
+};
+export default ButtonRemove;


### PR DESCRIPTION
Se agrega funcionalidad para eliminar un doctor, y se terminan los filtros por nombre y por especialidad en las vistas de Mis Profesionales. 
* Queda ajustar estilo de vista "Mis profesionales" y solucionar que una vez eliminado un doctor, se renderice de nuevo la vista.